### PR TITLE
README: mkdir /var/log/software-properties-station

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ The `software-properties-station` app is a simple graphical and command-line app
    sudo pip install . 
    ```
 
+4. Create a directory for the `.log` file:
+   ```bash
+   sudo mkdir /var/log/software-properties-station
+   ```
+
 ## Usage
 
 ### Graphical Interface


### PR DESCRIPTION
For systems where the directory does not yet exist: advise the user to create it.

## Summary by Sourcery

Documentation:
- Add instructions to create the /var/log/software-properties-station directory in the README.